### PR TITLE
Update app title to Nexus AI

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>AI Chat Assistant</title>
+    <title>Nexus AI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -15,5 +15,5 @@ test('renders chat container with title', () => {
   render(<App />);
   const chatContainer = screen.getByTestId('chat-container');
   expect(chatContainer).toBeInTheDocument();
-  expect(screen.getByText('AI Chat Assistant')).toBeInTheDocument();
+  expect(screen.getByText('Nexus AI')).toBeInTheDocument();
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,7 +5,7 @@ import './App.css';
 function App() {
   return (
     <div className="App">
-      <ChatContainer title="AI Chat Assistant" />
+      <ChatContainer title="Nexus AI" />
     </div>
   );
 }

--- a/ui/src/components/ChatContainer/ChatContainer.test.tsx
+++ b/ui/src/components/ChatContainer/ChatContainer.test.tsx
@@ -29,7 +29,7 @@ describe('ChatContainer Component', () => {
   it('renders with default title', () => {
     render(<ChatContainer />);
 
-    expect(screen.getByText('AI Chat')).toBeInTheDocument();
+    expect(screen.getByText('Nexus AI')).toBeInTheDocument();
   });
 
   it('renders with custom title', () => {

--- a/ui/src/components/ChatContainer/ChatContainer.tsx
+++ b/ui/src/components/ChatContainer/ChatContainer.tsx
@@ -8,7 +8,7 @@ interface ChatContainerProps {
   title?: string;
 }
 
-export const ChatContainer: React.FC<ChatContainerProps> = ({ title = 'AI Chat' }) => {
+export const ChatContainer: React.FC<ChatContainerProps> = ({ title = 'Nexus AI' }) => {
   const { messages, isLoading, error, sendMessage, clearMessages, clearError } = useChat();
 
   return (


### PR DESCRIPTION
- Changed from "AI Chat Assistant" to "Nexus AI"
- More concise and modern branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)